### PR TITLE
API Enhancement

### DIFF
--- a/openai_server/backend.py
+++ b/openai_server/backend.py
@@ -67,6 +67,24 @@ def get_client():
         client = get_gradio_client()
     return client
 
+def perform_login(client, kwargs):
+    """
+    Perform a login if a username, password, and langchain_mode was provided
+    in the following format: "username:passwprd:lanchain_mode"
+    """
+    user = kwargs['user']
+    if user:
+        args = user.split(':')
+        # only attempt to login if a langchain_mode was provided
+        if len(args) == 3:
+            langchain_mode = args[2]
+
+            # perform login
+            client.predict(langchain_mode, args[0], args[1], None, None, api_name='/login')
+
+            # add the langchain mode to the kwargs
+            kwargs['langchain_mode'] = langchain_mode
+
 
 def get_response(instruction, gen_kwargs, verbose=False, chunk_response=True, stream_output=False):
     import ast
@@ -101,6 +119,9 @@ def get_response(instruction, gen_kwargs, verbose=False, chunk_response=True, st
 
     # concurrent gradio client
     client = get_client()
+
+    # perform login if required
+    perform_login(client, kwargs)
 
     if stream_output:
         job = client.submit(str(dict(kwargs)), api_name='/submit_nochat_api')

--- a/src/gradio_runner.py
+++ b/src/gradio_runner.py
@@ -882,8 +882,8 @@ def go_gradio(**kwargs):
             if description is None:
                 description = ''
             gr.Markdown(f"""
-                {get_h2o_title(title, description, visible_h2ogpt_qrcode=kwargs['visible_h2ogpt_qrcode'])
-            if kwargs['h2ocolors'] else get_simple_title(title, description)}
+                {get_h2o_title(page_title, description, visible_h2ogpt_qrcode=kwargs['visible_h2ogpt_qrcode'])
+            if kwargs['h2ocolors'] else get_simple_title(page_title, description)}
                 """)
 
         # go button visible if
@@ -2907,7 +2907,8 @@ def go_gradio(**kwargs):
         eventdb_loginb = eventdb_logina.then(login_func,
                                              inputs=login_inputs,
                                              outputs=login_outputs,
-                                             queue=not kwargs['large_file_count_mode'])
+                                             queue=not kwargs['large_file_count_mode'],
+                                             api_name='login')
 
         admin_pass_textbox.submit(check_admin_pass, inputs=admin_pass_textbox, outputs=system_row,
                                   **noqueue_kwargs) \
@@ -3310,7 +3311,7 @@ def go_gradio(**kwargs):
                                      outputs=[my_db_state, selection_docs_state, langchain_mode,
                                               new_langchain_mode_text,
                                               langchain_mode_path_text],
-                                     api_name='new_langchain_mode_text' if allow_api and allow_upload_to_user_data else None)
+                                     api_name='new_langchain_mode_text' if allow_api and (allow_upload_to_user_data or allow_upload_to_my_data) else None)
         db_events.extend([eventdb20a, eventdb20b])
 
         remove_langchain_mode_func = functools.partial(remove_langchain_mode,


### PR DESCRIPTION
This merge request adds the following minor changes to the user interface:

- `src/gradio_runner.py`: Page Header - The functionality already exists to configure the page title via the CLI, but unfortunately, the page header is to "h2oGPT". This change sets the page header to the same as the page title.

Additional enhancements were made to allow user authentications via the API to allow h2oGPT to be used as a managed RAG service.

- `openai_server/backend.py`: If a username, password, and langchain_mode are provided in the following format in the user parameter: "username:password:langchain_mode", it allows for seamless RAG integration via the OpenAI API.
- `src/gradio_runner.py`: Add the option to use `login` from the Gradio API.